### PR TITLE
fix onSymImport passing wrong line info when import multiple modules

### DIFF
--- a/compiler/modules/importer.nim
+++ b/compiler/modules/importer.nim
@@ -294,7 +294,7 @@ proc transformImportAs(c: PContext; n: PNode): tuple[node: PNode, importHidden: 
     ret.node = n.processPragma
   return ret
 
-proc myImportModule(c: PContext, n: var PNode, importStmtResult: PNode): PSym =
+proc myImportModule(c: PContext, n: var PNode, info: TLineInfo, importStmtResult: PNode): PSym =
   let transf = transformImportAs(c, n)
   n = transf.node
   let f = checkModuleName(c.config, n)
@@ -332,7 +332,7 @@ proc myImportModule(c: PContext, n: var PNode, importStmtResult: PNode): PSym =
       localReport(c.config, n.info, reportSym(rsemDeprecated, realModule))
 
     if c.graph.onSymImport != nil:
-      c.graph.onSymImport(c.graph, n.info, result, c.graph.usageSym, false)
+      c.graph.onSymImport(c.graph, info, result, c.graph.usageSym, false)
 
     importStmtResult.add:
       case result.kind
@@ -353,10 +353,10 @@ proc afterImport(c: PContext, m: PSym) =
   else:
     discard
 
-proc impMod(c: PContext; it: PNode; importStmtResult: PNode): PNode =
+proc impMod(c: PContext; it: PNode; info: TLineInfo; importStmtResult: PNode): PNode =
   result = it
   let
-    m = myImportModule(c, result, importStmtResult)
+    m = myImportModule(c, result, info, importStmtResult)
     hasError = m.isError
 
   if m != nil:
@@ -397,9 +397,9 @@ proc evalImport*(c: PContext, n: PNode): PNode =
           else:
             x
 
-        hasError = impMod(c, imp, result).kind == nkError or hasError
+        hasError = impMod(c, imp, x.info, result).kind == nkError or hasError
     else:
-      hasError = impMod(c, it, result).kind == nkError
+      hasError = impMod(c, it, it.info, result).kind == nkError
 
   if hasError:
     result = c.config.wrapError(result)
@@ -409,7 +409,7 @@ proc evalFrom*(c: PContext, n: PNode): PNode =
   #       how they work, far too much mutation
   checkMinSonsLen(n, 2, c.config)
   result = newNodeI(nkFromStmt, n.info)
-  let m = myImportModule(c, n[0], result)
+  let m = myImportModule(c, n[0], n[0].info, result)
   var hasError = m.isError
   if m != nil:
     n[0] = newSymNode(m)
@@ -452,7 +452,7 @@ proc readExceptSet(c: PContext, n: PNode): IntSet =
 proc evalImportExcept*(c: PContext, n: PNode): PNode =
   checkMinSonsLen(n, 2, c.config)
   result = newNodeI(nkImportExceptStmt, n.info)
-  let m = myImportModule(c, n[0], result)
+  let m = myImportModule(c, n[0], n[0].info, result)
   var hasError = m.isError
 
   if m != nil:


### PR DESCRIPTION
<!--- The Pull Request (=PR) message is what will get automatically used as
the commit message when the PR is merged. Make sure that no line is longer
than 72 characters -->

discovered when developing language server, previously it passing 
transformed import statement line info, only first module can be resolved,
like `import std/[strformat, strutils]`, the `strutils` will not.
code below neither worked.
```nim
import std/[strformat as sformat]
import
  compiler/ast/[
    ast
  ]
```

---
<!-- Note: section break (`---`) onwards is not in CI merge commit -->

## Notes for Reviewers
this will not block language server development.

<!--
Pull Request(PR) Help

Before Merge Ensure:
* title reads like a short changelog line entry
* code includes tests and is documented
* leave the source better than before, but split out big reformats

See contributor (guide)[https://nim-works.github.io/nimskull/contributing.html]
for details, especially if you're new to this project.

Tips that make PRs easier:
* for big/impactful changes, start with chat/discussions to refine ideas
* refine the pull request message over time; don't have to nail it in one go
